### PR TITLE
Add target blank and noreferrer nopener rel to table links

### DIFF
--- a/src/components/Resources/ResourceTable.tsx
+++ b/src/components/Resources/ResourceTable.tsx
@@ -40,6 +40,8 @@ export default function ResourceTable() {
                                 <a
                                     className="text-orange-900 hover:underline"
                                     href={d.link}
+                                    rel="noreferrer noopener"
+                                    target="_blank"
                                 >
                                     {d.name}
                                 </a>


### PR DESCRIPTION
Fixes #25 

This PR adds the rel="noreferrer nopener" safety attribute and the target="_blank" to the table links for the resource table.

Was not able to test this locally as I don't have test data yet, but figure the change is fairly safe