### PR TITLE
Fix curlies error, add strict always to eqeqeq

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -47,8 +47,8 @@ module.exports = {
             },
         ],
         '@typescript-eslint/no-unsafe-assignment': 'warn',
-        curly: 'error',
+        curly: ['error', 'all'],
         'no-console': ['error', { allow: ['error', 'warn'] }],
-        eqeqeq: 2,
+        eqeqeq: ['error', 'always'],
     },
 }


### PR DESCRIPTION
This PR fixes the eslint rule for eqeqeq not erroring when left and right are same type, and adds the rule for curlies to always use curlies when possible